### PR TITLE
Feature/adapt to revised inntekt api

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/Application.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/Application.kt
@@ -56,7 +56,7 @@ class Application(
             val aktørId = packet.getStringValue(AKTØRID)
             val vedtakId = packet.getIntValue(VEDTAKID)
             val beregningsDato = packet.getLocalDate(BEREGNINGSDATO)
-            val klassifisertInntekt = inntektKlassifiserer.getInntekt(aktørId, vedtakId, beregningsDato)
+            val klassifisertInntekt = inntektKlassifiserer.getInntekt(aktørId, vedtakId.toString(), beregningsDato, null)
             packet.putValue(INNTEKT, klassifisertInntekt)
             return packet
         }

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/KlassifiserInntekt.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/KlassifiserInntekt.kt
@@ -12,9 +12,17 @@ import no.nav.dagpenger.events.inntekt.v1.SpesifisertInntekt
 class InntektKlassifiserer(private val inntektHttpClient: SpesifisertInntektHttpClient) {
     fun getInntekt(
         aktørId: String,
-        vedtakId: Int,
-        beregningsDato: LocalDate
-    ): Inntekt = klassifiserOgMapInntekt(inntektHttpClient.getSpesifisertInntekt(aktørId = aktørId, vedtakId = vedtakId, beregningsDato = beregningsDato))
+        vedtakId: String,
+        beregningsDato: LocalDate,
+        fødselsnummer: String? = null
+    ): Inntekt = klassifiserOgMapInntekt(
+        inntektHttpClient.getSpesifisertInntekt(
+            aktørId = aktørId,
+            vedtakId = vedtakId,
+            beregningsDato = beregningsDato,
+            fødselsnummer = fødselsnummer
+        )
+    )
 }
 
 internal fun klassifiserOgMapInntekt(spesifisertInntekt: SpesifisertInntekt): Inntekt {

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/LøsningService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/LøsningService.kt
@@ -1,6 +1,7 @@
 package no.nav.dagpenger.inntekt.klassifiserer
 
 import mu.KotlinLogging
+import mu.withLoggingContext
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageProblems
 import no.nav.helse.rapids_rivers.RapidsConnection
@@ -19,11 +20,7 @@ class LøsningService(
         River(rapidsConnection).apply {
             validate { it.demandAll("@behov", listOf(INNTEKT)) }
             validate { it.rejectKey("@løsning") }
-            validate { it.requireKey("@id") }
-            validate { it.requireKey(BEREGNINGSDATO) }
-            validate { it.requireKey(AKTØRID) }
-            validate { it.requireKey(FØDSELSNUNMER) }
-            validate { it.requireKey(VEDTAK_ID) }
+            validate { it.requireKey("@id", BEREGNINGSDATO, AKTØRID, FØDSELSNUNMER, VEDTAK_ID) }
         }.register(this)
     }
 
@@ -42,20 +39,25 @@ class LøsningService(
         val fødselsnummer = packet[FØDSELSNUNMER].asText()
         val beregningsDato = packet[BEREGNINGSDATO].asLocalDate()
 
-        try {
-            val inntekt = inntektKlassifiserer.getInntekt(
-                aktørId = aktørId,
-                vedtakId = vedtakId,
-                beregningsDato = beregningsDato,
-                fødselsnummer = fødselsnummer
-            )
-            packet["@løsning"] = mapOf(
-                INNTEKT to inntekt
-            )
-            context.send(packet.toJson())
-            logger.info { "løser behov for ${packet["@id"].asText()}" }
-        } catch (err: Exception) {
-            logger.error(err) { "feil ved innhenting av inntekt: ${err.message} for ${packet["@id"].asText()}" }
+        withLoggingContext(
+            "behovId" to packet["@id"].asText(),
+            "vedtakId" to packet["vedtakId"].asText()
+        ) {
+            try {
+                val inntekt = inntektKlassifiserer.getInntekt(
+                    aktørId = aktørId,
+                    vedtakId = vedtakId,
+                    beregningsDato = beregningsDato,
+                    fødselsnummer = fødselsnummer
+                )
+                packet["@løsning"] = mapOf(
+                    INNTEKT to inntekt
+                )
+                context.send(packet.toJson())
+                logger.info { "løser behov for ${packet["@id"].asText()}" }
+            } catch (err: Exception) {
+                logger.error(err) { "feil ved innhenting av inntekt: ${err.message} for ${packet["@id"].asText()}" }
+            }
         }
     }
 

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/LøsningService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/LøsningService.kt
@@ -22,6 +22,8 @@ class LøsningService(
             validate { it.requireKey("@id") }
             validate { it.requireKey(BEREGNINGSDATO) }
             validate { it.requireKey(AKTØRID) }
+            validate { it.requireKey(FØDSELSNUNMER) }
+            validate { it.requireKey(VEDTAK_ID) }
         }.register(this)
     }
 
@@ -29,16 +31,24 @@ class LøsningService(
         const val INNTEKT: String = "Inntekt"
         const val BEREGNINGSDATO: String = "beregningsdato"
         const val AKTØRID: String = "aktørId"
+        const val FØDSELSNUNMER: String = "fødselsnummer"
+        const val VEDTAK_ID: String = "vedtakId"
         private val logger = KotlinLogging.logger {}
     }
 
     override fun onPacket(packet: JsonMessage, context: RapidsConnection.MessageContext) {
         val aktørId = packet[AKTØRID].asText()
-        val vedtakId = -1337 // @todo - gjøre inntektapi uavhengig av vedtak id
+        val vedtakId = packet[VEDTAK_ID].asText()
+        val fødselsnummer = packet[FØDSELSNUNMER].asText()
         val beregningsDato = packet[BEREGNINGSDATO].asLocalDate()
 
         try {
-            val inntekt = inntektKlassifiserer.getInntekt(aktørId, vedtakId, beregningsDato)
+            val inntekt = inntektKlassifiserer.getInntekt(
+                aktørId = aktørId,
+                vedtakId = vedtakId,
+                beregningsDato = beregningsDato,
+                fødselsnummer = fødselsnummer
+            )
             packet["@løsning"] = mapOf(
                 INNTEKT to inntekt
             )

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/SpesifisertInntektHttpClient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/SpesifisertInntektHttpClient.kt
@@ -15,16 +15,18 @@ class SpesifisertInntektHttpClient(private val inntektApiUrl: String, private va
 
     fun getSpesifisertInntekt(
         aktørId: String,
-        vedtakId: Int,
-        beregningsDato: LocalDate
+        vedtakId: String,
+        beregningsDato: LocalDate,
+        fødselsnummer: String?
     ): SpesifisertInntekt {
 
         val url = "${inntektApiUrl}v1/inntekt/spesifisert"
 
         val requestBody = SpesifisertInntektRequest(
-            aktørId,
-            vedtakId,
-            beregningsDato
+            aktørId = aktørId,
+            fødselsnummer = fødselsnummer,
+            vedtakId = vedtakId,
+            beregningsDato = beregningsDato
         )
         val jsonBody = jsonRequestRequestAdapter.toJson(requestBody)
 
@@ -36,8 +38,8 @@ class SpesifisertInntektHttpClient(private val inntektApiUrl: String, private va
         }
 
         return result.fold(
-            {
-                spesifisertInntekt -> spesifisertInntekt
+            { spesifisertInntekt ->
+                spesifisertInntekt
             },
             { error ->
                 val problem = runCatching {
@@ -60,10 +62,12 @@ class SpesifisertInntektHttpClient(private val inntektApiUrl: String, private va
 
 private data class SpesifisertInntektRequest(
     val aktørId: String,
-    val vedtakId: Int,
+    val fødselsnummer: String? = null,
+    val vedtakId: String,
     val beregningsDato: LocalDate
 )
 
 private fun String.toBearerToken() = "Bearer $this"
 
-class InntektApiHttpClientException(override val message: String, val problem: Problem, override val cause: Throwable) : RuntimeException(message, cause)
+class InntektApiHttpClientException(override val message: String, val problem: Problem, override val cause: Throwable) :
+    RuntimeException(message, cause)

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/klassifiserer/FilterPredicatesTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/klassifiserer/FilterPredicatesTest.kt
@@ -39,8 +39,9 @@ class OnPacketTest {
         every {
             inntektKlassifiserer.getInntekt(
                 "123",
-                12345,
-                LocalDate.of(2020, 1, 1)
+                "12345",
+                LocalDate.of(2020, 1, 1),
+                null
             )
         } returns inntekt
 

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/klassifiserer/InntektKlassifisererTopologyTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/klassifiserer/InntektKlassifisererTopologyTest.kt
@@ -97,8 +97,9 @@ class InntektKlassifisererTopologyTest {
         every {
             inntektKlassifiserer.getInntekt(
                 "12345",
-                123,
-                LocalDate.of(2019, 1, 25)
+                "123",
+                LocalDate.of(2019, 1, 25),
+                null
             )
         } returns inntekt
 
@@ -138,8 +139,9 @@ class InntektKlassifisererTopologyTest {
         every {
             inntektKlassifiserer.getInntekt(
                 "12345",
-                123,
-                LocalDate.of(2019, 1, 25)
+                "123",
+                LocalDate.of(2019, 1, 25),
+                null
             )
         } returns inntekt
 

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/klassifiserer/LøsningServiceTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/klassifiserer/LøsningServiceTest.kt
@@ -50,7 +50,7 @@ internal class LøsningServiceTest {
     }
 
     private val inntektKlassifiserer = mockk<InntektKlassifiserer>(relaxed = true).also {
-        every { it.getInntekt(any(), any(), any()) } returns inntekt
+        every { it.getInntekt(any(), any(), any(), any()) } returns inntekt
     }
 
     private val rapid = TestRapid().apply {
@@ -70,6 +70,8 @@ internal class LøsningServiceTest {
                 "@behov": ["$INNTEKT"],
                 "@id" : "12345", 
                 "aktørId" : "1234",
+                "fødselsnummer" : "1234",
+                "vedtakId" : "vedtakId122423231ljnds",
                 "beregningsdato": "2020-04-21"
              }
             """.trimIndent()


### PR DESCRIPTION
Vedtakid er string nå. Inntektapi tar i mot fødselsnummer som parameter. Inntektbehovsløser krever nå `vedtakId` og `fødselsnummer` på behovspakka. Svarer på behovet `Inntekt`

navikt/dagpenger#397

PR - navikt/dp-inntekt-api#88 MÅ merges før denne går ut.