### PR TITLE
Løsningsservice i rapid-rivers gir nå kun inntektsid som løsning

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,10 @@ application {
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
 
+    // scientist to compare klassifisering from dp-inntekt-api and local
+    implementation("com.github.rawls238:Scientist4JCore:0.8")
+    implementation(Micrometer.prometheusRegistry)
+
     // Dagpenger
     implementation(Dagpenger.Streams)
     implementation(Dagpenger.Events)

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/Application.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/Application.kt
@@ -70,7 +70,7 @@ fun main() {
     val apiKey = apiKeyVerifier.generate(configuration.applicationConfig.inntektApiKey)
 
     val inntektKlassifiserer = InntektKlassifiserer(
-        inntektHttpClient = SpesifisertInntektHttpClient(
+        inntektHttpClient = InntektHttpClient(
             configuration.applicationConfig.inntektApiUrl,
             apiKey
         ))

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/JsonAdapters.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/JsonAdapters.kt
@@ -1,7 +1,9 @@
 package no.nav.dagpenger.inntekt.klassifiserer
 
 import com.squareup.moshi.JsonAdapter
+import no.nav.dagpenger.events.inntekt.v1.Inntekt
 import no.nav.dagpenger.events.inntekt.v1.SpesifisertInntekt
 import no.nav.dagpenger.events.moshiInstance
 
 val spesifisertInntektJsonAdapter: JsonAdapter<SpesifisertInntekt> = moshiInstance.adapter(SpesifisertInntekt::class.java)
+val klassifisertInntektJsonAdapter: JsonAdapter<Inntekt> = moshiInstance.adapter(Inntekt::class.java)

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/LøsningService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/LøsningService.kt
@@ -51,7 +51,7 @@ class LøsningService(
                     fødselsnummer = fødselsnummer
                 )
                 packet["@løsning"] = mapOf(
-                    INNTEKT to inntekt
+                    INNTEKT to inntekt.inntektsId
                 )
                 context.send(packet.toJson())
                 logger.info { "løser behov for ${packet["@id"].asText()}" }

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/klassifiserer/InntektHttpClientTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/klassifiserer/InntektHttpClientTest.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-class SpesifisertInntektHttpClientTest {
+class InntektHttpClientTest {
 
     companion object {
         val server: WireMockServer = WireMockServer(WireMockConfiguration.options().dynamicPort())
@@ -41,7 +41,7 @@ class SpesifisertInntektHttpClientTest {
     @Test
     fun `fetch spesifisert inntekt on 200 ok`() {
 
-        val responseBodyJson = SpesifisertInntektHttpClientTest::class.java
+        val responseBodyJson = InntektHttpClientTest::class.java
             .getResource("/test-data/example-spesifisert-inntekt-payload.json").readText()
 
         WireMock.stubFor(
@@ -63,13 +63,13 @@ class SpesifisertInntektHttpClientTest {
                 )
         )
 
-        val spesifisertInntektHttpClient = SpesifisertInntektHttpClient(
+        val inntektHttpClient = InntektHttpClient(
             server.url(""),
             "api-key"
         )
 
         val spesifisertInntekt =
-            spesifisertInntektHttpClient.getSpesifisertInntekt(
+            inntektHttpClient.getSpesifisertInntekt(
                 "45456",
                 "123",
                 LocalDate.now(),
@@ -83,7 +83,7 @@ class SpesifisertInntektHttpClientTest {
     @Test
     fun `fetch spesifisert inntekt on 200 ok with fødselsnummer`() {
 
-        val responseBodyJson = SpesifisertInntektHttpClientTest::class.java
+        val responseBodyJson = InntektHttpClientTest::class.java
             .getResource("/test-data/example-spesifisert-inntekt-payload.json").readText()
 
         WireMock.stubFor(
@@ -108,13 +108,13 @@ class SpesifisertInntektHttpClientTest {
                 )
         )
 
-        val spesifisertInntektHttpClient = SpesifisertInntektHttpClient(
+        val inntektHttpClient = InntektHttpClient(
             server.url(""),
             "api-key"
         )
 
         val spesifisertInntekt =
-            spesifisertInntektHttpClient.getSpesifisertInntekt(
+            inntektHttpClient.getSpesifisertInntekt(
                 "45456",
                 "123",
                 LocalDate.now(),
@@ -123,6 +123,51 @@ class SpesifisertInntektHttpClientTest {
 
         assertEquals("01D8G6FS9QGRT3JKBTA5KEE64C", spesifisertInntekt.inntektId.id)
         assertEquals(4, spesifisertInntekt.posteringer.size)
+    }
+
+    @Test
+    fun `fetch klassifisert inntekt on 200 ok with fødselsnummer`() {
+
+        val responseBodyJson = InntektHttpClientTest::class.java
+            .getResource("/test-data/example-klassifisert-inntekt-payload.json").readText()
+
+        WireMock.stubFor(
+            WireMock.post(WireMock.urlEqualTo("/v1/inntekt/klassifisert"))
+                .withHeader("X-API-KEY", EqualToPattern("api-key"))
+                .withRequestBody(
+                    matchingJsonPath("aktørId", equalTo("45456"))
+                )
+                .withRequestBody(
+                    matchingJsonPath("vedtakId", equalTo("123"))
+                )
+                .withRequestBody(
+                    matchingJsonPath("beregningsDato", matching("^\\d{4}-\\d{2}-\\d{2}\$"))
+                )
+                .withRequestBody(
+                    matchingJsonPath("fødselsnummer", equalTo("12345678901"))
+                )
+                .willReturn(
+                    WireMock.aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(responseBodyJson)
+                )
+        )
+
+        val inntektHttpClient = InntektHttpClient(
+            server.url(""),
+            "api-key"
+        )
+
+        val klassifisertInntekt =
+            inntektHttpClient.getKlassifisertInntekt(
+                "45456",
+                "123",
+                LocalDate.now(),
+                "12345678901"
+            )
+
+        assertEquals("12345", klassifisertInntekt.inntektsId)
+        assertEquals(2, klassifisertInntekt.inntektsListe.size)
     }
 
     @Test
@@ -148,7 +193,7 @@ class SpesifisertInntektHttpClientTest {
                 )
         )
 
-        val spesifisertInntektHttpClient = SpesifisertInntektHttpClient(
+        val spesifisertInntektHttpClient = InntektHttpClient(
             server.url(""),
             "api-key"
         )
@@ -179,7 +224,7 @@ class SpesifisertInntektHttpClientTest {
                 )
         )
 
-        val spesifisertInntektHttpClient = SpesifisertInntektHttpClient(
+        val spesifisertInntektHttpClient = InntektHttpClient(
             server.url(""),
             "api-"
         )

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/klassifiserer/LøsningServiceTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/klassifiserer/LøsningServiceTest.kt
@@ -1,10 +1,6 @@
 package no.nav.dagpenger.inntekt.klassifiserer
 
-import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.ints.shouldBeExactly
@@ -25,13 +21,9 @@ import org.junit.jupiter.api.Test
 internal class LøsningServiceTest {
 
     companion object {
-        private val objectMapper = jacksonObjectMapper()
-            .registerModule(JavaTimeModule())
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-
+        private val inntektsId = "221212"
         private val inntekt = Inntekt(
-            inntektsId = "inntektsid",
+            inntektsId = inntektsId,
             manueltRedigert = false,
             inntektsListe = listOf(
                 KlassifisertInntektMåned(
@@ -63,7 +55,7 @@ internal class LøsningServiceTest {
     }
 
     @Test
-    fun ` Skal innhente løsning for inntekstbehov`() {
+    fun ` Skal innhente løsning for inntektsbehov`() {
         rapid.sendTestMessage(
             """
              {
@@ -83,17 +75,7 @@ internal class LøsningServiceTest {
             inspektør.size shouldBeExactly 1
             inspektør.field(0, "@behov").map(JsonNode::asText) shouldContain INNTEKT
             inspektør.field(0, "@løsning").hasNonNull(INNTEKT)
-            inspektør.field(0, "@løsning")[INNTEKT].hasNonNull("inntektsId")
-            inspektør.field(0, "@løsning")[INNTEKT].hasNonNull("inntektsListe")
-            inspektør.field(0, "@løsning")[INNTEKT].hasNonNull("sisteAvsluttendeKalenderMåned")
-
-            val inntektFraPacket: Inntekt =
-                objectMapper.treeToValue(inspektør.field(0, "@løsning")[INNTEKT], Inntekt::class.java)
-
-            inntekt.inntektsId shouldBe inntektFraPacket.inntektsId
-            inntekt.inntektsListe shouldBe inntektFraPacket.inntektsListe
-            inntekt.manueltRedigert shouldBe inntektFraPacket.manueltRedigert
-            inntekt.sisteAvsluttendeKalenderMåned shouldBe inntektFraPacket.sisteAvsluttendeKalenderMåned
+            inspektør.field(0, "@løsning")[INNTEKT].asText() shouldBe inntektsId
         }
     }
 }


### PR DESCRIPTION
Prøver scientist for å kjøre nytt endepunkt som klassifiserer inntekt fra dp-inntekt-api
Fra
https://github.com/rawls238/Scientist4J

```
Behind the scenes the following occurs in both cases:

- It decides whether or not to run the candidate function
- Measures the durations of all behaviors
- Compares the result of the two
- Swallows (but records) any exceptions raised by the candidate
- Publishes all this information.
```

navikt/dagpenger#406