### PR TITLE
Hent inntekt basert på inntektid for å støtte reberegning (spesielt g…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,9 @@ dependencies {
     implementation(Dagpenger.Events)
     implementation(Dagpenger.Biblioteker.ktorUtils)
 
+    // gRpc
+    implementation("com.github.navikt:dp-inntekt:2020.05.18-11.33.279ab2f32a2c")
+
     // rapid and rivers
     implementation(RapidAndRivers)
 

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/Application.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/Application.kt
@@ -2,7 +2,10 @@ package no.nav.dagpenger.inntekt.klassifiserer
 
 import java.time.LocalDateTime
 import java.util.Properties
+import kotlinx.coroutines.runBlocking
 import no.nav.dagpenger.events.Packet
+import no.nav.dagpenger.inntekt.rpc.InntektHenter
+import no.nav.dagpenger.inntekt.rpc.InntektHenterWrapper
 import no.nav.dagpenger.ktor.auth.ApiKeyVerifier
 import no.nav.dagpenger.streams.HealthCheck
 import no.nav.dagpenger.streams.HealthStatus
@@ -16,7 +19,8 @@ import org.apache.kafka.streams.kstream.Predicate
 class Application(
     private val configuration: Configuration,
     private val inntektHttpClient: InntektHttpClient,
-    private val healthCheck: HealthCheck
+    private val healthCheck: HealthCheck,
+    private val inntektHenter: InntektHenter
 ) : River(configuration.kafka.behovTopic) {
 
     override val healthChecks: List<HealthCheck> = listOf(healthCheck)
@@ -28,6 +32,7 @@ class Application(
         const val VEDTAKID = "vedtakId"
         const val MANUELT_GRUNNLAG = "manueltGrunnlag"
         const val BEREGNINGSDATO = "beregningsDato"
+        const val INNTEKTS_ID = "inntektsId"
     }
 
     override fun getConfig(): Properties {
@@ -50,13 +55,21 @@ class Application(
             packet.getNullableStringValue("system_started")
                 ?.let { runCatching { LocalDateTime.parse(it) }.getOrNull() }
 
+        val inntektsId = packet.getNullableStringValue(INNTEKTS_ID)
         if (started?.isBefore(LocalDateTime.now().minusSeconds(30)) == true) {
             throw RuntimeException("Denne pakka er for gammal!")
         } else {
-            val aktørId = packet.getStringValue(AKTØRID)
-            val vedtakId = packet.getIntValue(VEDTAKID)
-            val beregningsDato = packet.getLocalDate(BEREGNINGSDATO)
-            val klassifisertInntekt = inntektHttpClient.getKlassifisertInntekt(aktørId, vedtakId.toString(), beregningsDato, null)
+
+            val klassifisertInntekt = when (inntektsId) {
+                is String -> runBlocking { inntektHenter.hentKlassifisertInntekt(inntektsId) }
+                else -> {
+                    val aktørId = packet.getStringValue(AKTØRID)
+                    val vedtakId = packet.getIntValue(VEDTAKID)
+                    val beregningsDato = packet.getLocalDate(BEREGNINGSDATO)
+                    inntektHttpClient.getKlassifisertInntekt(aktørId, vedtakId.toString(), beregningsDato, null)
+                }
+            }
+
             packet.putValue(INNTEKT, klassifisertInntekt)
             return packet
         }
@@ -69,6 +82,11 @@ fun main() {
     val apiKeyVerifier = ApiKeyVerifier(configuration.applicationConfig.inntektApiSecret)
     val apiKey = apiKeyVerifier.generate(configuration.applicationConfig.inntektApiKey)
 
+    val inntektGrpcClient = InntektHenterWrapper(
+        serveraddress = configuration.applicationConfig.inntektGrpcAddress,
+        apiKey = apiKey
+    )
+
     val inntektHttpClient = InntektHttpClient(
             configuration.applicationConfig.inntektApiUrl,
             apiKey
@@ -77,6 +95,7 @@ fun main() {
     Application(
         configuration = configuration,
         inntektHttpClient = inntektHttpClient,
+        inntektHenter = inntektGrpcClient,
         healthCheck = RapidHealthCheck as HealthCheck
     ).start()
 

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/Application.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/Application.kt
@@ -87,6 +87,10 @@ fun main() {
         apiKey = apiKey
     )
 
+    Runtime.getRuntime().addShutdownHook(Thread {
+        inntektGrpcClient.close()
+    })
+
     val inntektHttpClient = InntektHttpClient(
             configuration.applicationConfig.inntektApiUrl,
             apiKey

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/Configuration.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/Configuration.kt
@@ -21,6 +21,7 @@ private val localProperties = ConfigurationMap(
         "dp.inntekt.api.key" to "dp-datalaster-inntekt",
         "dp.inntekt.api.secret" to "secret",
         "dp.inntekt.api.url" to "http://localhost/",
+        "inntekt.grpc.address" to "localhost",
         "kafka.bootstrap.servers" to "localhost:9092",
         "kafka.topic" to TOPIC,
         "kafka.reset.policy" to "earliest",
@@ -38,6 +39,7 @@ private val devProperties = ConfigurationMap(
         "application.httpPort" to "8080",
         "behov.topic" to Topics.DAGPENGER_BEHOV_PACKET_EVENT.name,
         "dp.inntekt.api.url" to "http://dp-inntekt-api//",
+        "inntekt.grpc.address" to "dp-inntekt-api-grpc.default.svc.nais.local",
         "kafka.bootstrap.servers" to "b27apvl00045.preprod.local:8443,b27apvl00046.preprod.local:8443,b27apvl00047.preprod.local:8443",
         "kafka.topic" to TOPIC,
         "kafka.reset.policy" to "earliest",
@@ -52,6 +54,7 @@ private val prodProperties = ConfigurationMap(
         "application.httpPort" to "8080",
         "behov.topic" to Topics.DAGPENGER_BEHOV_PACKET_EVENT.name,
         "dp.inntekt.api.url" to "http://dp-inntekt-api/",
+        "inntekt.grpc.address" to "dp-inntekt-api-grpc.default.svc.nais.local",
         "kafka.bootstrap.servers" to "a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00149.adeo.no:8443",
         "kafka.topic" to TOPIC,
         "kafka.reset.policy" to "earliest",
@@ -89,7 +92,8 @@ data class ApplicationConfig(
     val inntektApiUrl: String = config()[Key("dp.inntekt.api.url", stringType)],
     val inntektApiKey: String = config()[Key("dp.inntekt.api.key", stringType)],
     val inntektApiSecret: String = config()[Key("dp.inntekt.api.secret", stringType)],
-    val unleashUrl: String = config()[Key("unleash.url", stringType)]
+    val unleashUrl: String = config()[Key("unleash.url", stringType)],
+    val inntektGrpcAddress: String = config()[Key("inntekt.grpc.address", stringType)]
 )
 
 enum class Profile {

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/klassifiserer/FilterPredicatesTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/klassifiserer/FilterPredicatesTest.kt
@@ -48,7 +48,8 @@ class OnPacketTest {
         val app = Application(
             configuration = Configuration(),
             inntektHttpClient = inntektHttpClient,
-            healthCheck = mockk(relaxed = true)
+            healthCheck = mockk(relaxed = true),
+            inntektHenter = mockk(relaxed = true)
         )
 
         val inputPacket = Packet()
@@ -69,7 +70,12 @@ class FilterPredicatesTest {
         val packet = Packet().apply {
             putValue("manueltGrunnlag", 1000)
         }
-        val app = Application(configuration = Configuration(), inntektHttpClient = mockk(), healthCheck = mockk(relaxed = true))
+        val app = Application(
+            configuration = Configuration(),
+            inntektHttpClient = mockk(),
+            healthCheck = mockk(relaxed = true),
+            inntektHenter = mockk(relaxed = true)
+        )
         app.filterPredicates().all { it.test("", packet) } shouldBe false
     }
 
@@ -77,7 +83,12 @@ class FilterPredicatesTest {
     fun `Skal legge på inntekt der det er ikke er manuelt grunnlag`() {
         val packet = Packet()
         packet.putValue("vedtakId", 123)
-        val app = Application(configuration = Configuration(), inntektHttpClient = mockk(), healthCheck = mockk(relaxed = true))
+        val app = Application(
+            configuration = Configuration(),
+            inntektHttpClient = mockk(),
+            healthCheck = mockk(relaxed = true),
+            inntektHenter = mockk(relaxed = true)
+        )
         app.filterPredicates().all { it.test("", packet) } shouldBe true
     }
 }


### PR DESCRIPTION
…-justering).

Issue navikt/dagpenger#317


Hente inntekt basert på InntektsId i dp-inntekt-klassifiserer, ser ut til at dette ble borte under flytting fra dp-datalaster-inntekt (https://github.com/navikt/dp-datalaster-inntekt/blob/master/src/main/kotlin/no/nav/dagpenger/datalaster/inntekt/Datalaster.kt#L51-L60)

