### PR TITLE
Feature/støtte fnr

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/InntektBehovløser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/InntektBehovløser.kt
@@ -23,6 +23,7 @@ internal class InntektBehovløser(rapidsConnection: RapidsConnection, private va
         const val BEHOV_ID = "behovId"
         const val INNTEKT = "inntektV1"
         const val AKTØRID = "aktørId"
+        const val FØDSELSNUMMER = "fødselsnummer"
         const val MANUELT_GRUNNLAG = "manueltGrunnlag"
         const val FORRIGE_GRUNNLAG = "forrigeGrunnlag"
         const val BEREGNINGSDATO = "beregningsDato"
@@ -39,6 +40,7 @@ internal class InntektBehovløser(rapidsConnection: RapidsConnection, private va
                     AKTØRID,
                     KONTEKST_ID,
                     KONTEKST_TYPE,
+                    FØDSELSNUMMER,
                 )
             }
             validate { it.rejectKey(INNTEKT, MANUELT_GRUNNLAG, FORRIGE_GRUNNLAG) }

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/InntektBehovløser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/InntektBehovløser.kt
@@ -5,6 +5,7 @@ import mu.KotlinLogging
 import mu.withLoggingContext
 import no.nav.dagpenger.inntekt.klassifiserer.PacketParser.aktørId
 import no.nav.dagpenger.inntekt.klassifiserer.PacketParser.beregningsdato
+import no.nav.dagpenger.inntekt.klassifiserer.PacketParser.fødselsnummer
 import no.nav.dagpenger.inntekt.klassifiserer.PacketParser.hentRegelkontekst
 import no.nav.dagpenger.inntekt.klassifiserer.PacketParser.inntektsId
 import no.nav.helse.rapids_rivers.JsonMessage
@@ -75,7 +76,13 @@ internal class InntektBehovløser(rapidsConnection: RapidsConnection, private va
                         }
 
                         else -> {
-                            val aktørId: String = packet.aktørId() ?: throw IllegalArgumentException("Mangler aktørId")
+                            val aktørId: String? = packet.aktørId()
+                            val fødselsnummer: String? = packet.fødselsnummer()
+
+                            if (aktørId == null && fødselsnummer == null) {
+                                throw IllegalArgumentException("Mangler aktørId eller fødselsnummer")
+                            }
+
                             requireNotNull(regelkontekst) { "Må ha en kontekst for å hente inntekt" }
 
                             val beregningsdato: LocalDate =

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/InntektHttpClient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/InntektHttpClient.kt
@@ -29,7 +29,7 @@ internal class InntektHttpClient(
     private val tokenProvider: () -> String,
 ) {
     suspend fun getKlassifisertInntekt(
-        aktørId: String,
+        aktørId: String?,
         regelkontekst: RegelKontekst,
         beregningsDato: LocalDate,
         fødselsnummer: String?,
@@ -70,7 +70,7 @@ internal class InntektHttpClient(
     }
 
     private suspend inline fun <reified T : Any> getInntekt(
-        aktørId: String,
+        aktørId: String?,
         regelkontekst: RegelKontekst,
         beregningsDato: LocalDate,
         fødselsnummer: String?,
@@ -120,7 +120,7 @@ internal class InntektHttpClient(
 }
 
 private data class InntektRequest(
-    val aktørId: String,
+    val aktørId: String?,
     val fødselsnummer: String? = null,
     val regelkontekst: RegelKontekst,
     val beregningsDato: LocalDate,

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/PacketParser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/PacketParser.kt
@@ -3,6 +3,7 @@ package no.nav.dagpenger.inntekt.klassifiserer
 import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.AKTØRID
 import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.BEHOV_ID
 import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.BEREGNINGSDATO
+import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.FØDSELSNUMMER
 import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.INNTEKT_ID
 import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.KONTEKST_ID
 import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.KONTEKST_TYPE
@@ -26,6 +27,12 @@ object PacketParser {
     fun JsonMessage.aktørId() =
         when (this.harVerdi(AKTØRID)) {
             true -> this[AKTØRID].asText()
+            false -> null
+        }
+
+    fun JsonMessage.fødselsnummer() =
+        when (this.harVerdi(FØDSELSNUMMER)) {
+            true -> this[FØDSELSNUMMER].asText()
             false -> null
         }
 

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/klassifiserer/InntektBehovløserTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/klassifiserer/InntektBehovløserTest.kt
@@ -102,14 +102,13 @@ class InntektBehovløserTest {
                    "$KONTEKST_ID" : "kontekstId", 
                    "$BEHOV_ID":"kaktus"
                 }
-                
                 """.trimIndent(),
             )
         }
     }
 
     @Test
-    fun `Kaster exception dersom aktørId ikke er satt for behov uten inntektId`() {
+    fun `Kaster exception dersom aktørId  eller fødselsnummer ikke er satt for behov uten inntektId`() {
         InntektBehovløser(testRapid, mockk())
 
         shouldThrow<IllegalArgumentException> {

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/klassifiserer/PacketParserTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/klassifiserer/PacketParserTest.kt
@@ -4,12 +4,14 @@ import io.kotest.matchers.shouldBe
 import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.AKTØRID
 import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.BEHOV_ID
 import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.BEREGNINGSDATO
+import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.FØDSELSNUMMER
 import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.INNTEKT_ID
 import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.KONTEKST_ID
 import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.KONTEKST_TYPE
 import no.nav.dagpenger.inntekt.klassifiserer.PacketParser.aktørId
 import no.nav.dagpenger.inntekt.klassifiserer.PacketParser.behovId
 import no.nav.dagpenger.inntekt.klassifiserer.PacketParser.beregningsdato
+import no.nav.dagpenger.inntekt.klassifiserer.PacketParser.fødselsnummer
 import no.nav.dagpenger.inntekt.klassifiserer.PacketParser.hentRegelkontekst
 import no.nav.dagpenger.inntekt.klassifiserer.PacketParser.inntektsId
 import no.nav.helse.rapids_rivers.JsonMessage
@@ -63,6 +65,17 @@ class PacketParserTest {
 
         testRapid.sendTestMessage(testMessageMedRequiredFelter())
         behovløser.packet.aktørId() shouldBe null
+    }
+
+    @Test
+    fun `Skal mappe fødselnummer`() {
+        val behovløser = OnPacketTestListener(testRapid)
+
+        testRapid.sendTestMessage(testMessageMedRequiredFelter(mapOf(FØDSELSNUMMER to "fnr")))
+        behovløser.packet.fødselsnummer() shouldBe "fnr"
+
+        testRapid.sendTestMessage(testMessageMedRequiredFelter())
+        behovløser.packet.fødselsnummer() shouldBe null
     }
 
     @Test

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/klassifiserer/RapidFilterTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/klassifiserer/RapidFilterTest.kt
@@ -7,6 +7,7 @@ import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.AKTØ
 import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.BEHOV_ID
 import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.BEREGNINGSDATO
 import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.FORRIGE_GRUNNLAG
+import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.FØDSELSNUMMER
 import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.INNTEKT
 import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.INNTEKT_ID
 import no.nav.dagpenger.inntekt.klassifiserer.InntektBehovløser.Companion.KONTEKST_ID
@@ -56,6 +57,7 @@ class RapidFilterTest {
             testListener.jsonMessage[BEREGNINGSDATO]
             testListener.jsonMessage[INNTEKT_ID]
             testListener.jsonMessage[AKTØRID]
+            testListener.jsonMessage[FØDSELSNUMMER]
             testListener.jsonMessage[KONTEKST_ID]
             testListener.jsonMessage[KONTEKST_TYPE]
         }


### PR DESCRIPTION
Støtte fødselsnummer ved innhenting av klassifisert inntekt. 

Det viser seg at dp-inntekt-api støtter uthenting av klassifisert inntekt  med enten aktørid/personnummer/begge felter satt. 